### PR TITLE
query: monitor custom servers

### DIFF
--- a/query/src/cli.rs
+++ b/query/src/cli.rs
@@ -5,6 +5,7 @@ use std::{
     fmt::{self, Write},
     process,
     str::FromStr,
+    time::Duration,
 };
 
 use getopts::Options;
@@ -119,8 +120,8 @@ impl Default for Filter {
 pub struct Cli {
     pub masters: Vec<Box<str>>,
     pub args: Vec<String>,
-    pub master_timeout: u32,
-    pub server_timeout: u32,
+    pub master_timeout: Duration,
+    pub server_timeout: Duration,
     pub protocol: Vec<u8>,
     pub json: bool,
     pub debug: bool,
@@ -138,8 +139,8 @@ impl Default for Cli {
                 .map(|i| i.to_string().into_boxed_str())
                 .collect(),
             args: Default::default(),
-            master_timeout: 2,
-            server_timeout: 2,
+            master_timeout: Duration::from_secs(2),
+            server_timeout: Duration::from_secs(2),
             protocol: vec![proto::PROTOCOL_VERSION, proto::PROTOCOL_VERSION - 1],
             json: false,
             debug: false,
@@ -159,7 +160,7 @@ COMMANDS:
     all                 fetch servers from all masters and fetch info for each server
     info hosts...       fetch info for each server
     list                fetch servers from all masters and print server addresses
-    monitor             live monitoring for server updates\
+    monitor [hosts]     live monitoring for server updates\
         "
     );
     print!("{}", opts.usage(&brief));
@@ -183,12 +184,12 @@ pub fn parse() -> Cli {
     opts.optopt("M", "master", &help, "LIST");
     let help = format!(
         "time to wait results from masters [default: {}]",
-        cli.master_timeout
+        cli.master_timeout.as_secs()
     );
     opts.optopt("T", "master-timeout", &help, "SECONDS");
     let help = format!(
         "time to wait results from servers [default: {}]",
-        cli.server_timeout
+        cli.server_timeout.as_secs()
     );
     opts.optopt("t", "server-timeout", &help, "SECONDS");
     let protocols = cli
@@ -249,7 +250,7 @@ pub fn parse() -> Cli {
     }
 
     match matches.opt_get("master-timeout") {
-        Ok(Some(t)) => cli.master_timeout = t,
+        Ok(Some(t)) => cli.master_timeout = Duration::from_secs(t),
         Ok(None) => {}
         Err(_) => {
             eprintln!("Invalid master-timeout");
@@ -258,7 +259,7 @@ pub fn parse() -> Cli {
     }
 
     match matches.opt_get("server-timeout") {
-        Ok(Some(t)) => cli.server_timeout = t,
+        Ok(Some(t)) => cli.server_timeout = Duration::from_secs(t),
         Ok(None) => {}
         Err(_) => {
             eprintln!("Invalid server-timeout");

--- a/query/src/list_servers.rs
+++ b/query/src/list_servers.rs
@@ -1,8 +1,4 @@
-use std::{
-    collections::HashSet,
-    net::SocketAddr,
-    time::{Duration, Instant},
-};
+use std::{collections::HashSet, net::SocketAddr, time::Instant};
 
 use serde::Serialize;
 use xash3d_observer::Handler;
@@ -11,7 +7,7 @@ use crate::{cli::Cli, QueryError};
 
 #[derive(Clone, Debug, Serialize)]
 struct ListResult<'a> {
-    master_timeout: u32,
+    master_timeout: u64,
     masters: &'a [Box<str>],
     filter: &'a str,
     servers: &'a [SocketAddr],
@@ -24,9 +20,8 @@ struct CollectServers {
 
 impl CollectServers {
     fn new(cli: &Cli) -> Self {
-        let timeout = Duration::from_secs(cli.master_timeout as u64);
         Self {
-            end_time: Instant::now() + timeout,
+            end_time: Instant::now() + cli.master_timeout,
             servers: HashSet::with_capacity(256),
         }
     }
@@ -46,7 +41,7 @@ impl Handler for CollectServers {
 fn print_server_list(cli: &Cli, servers: &[SocketAddr]) {
     if cli.json || cli.debug {
         let result = ListResult {
-            master_timeout: cli.master_timeout,
+            master_timeout: cli.master_timeout.as_secs(),
             masters: &cli.masters,
             filter: &cli.filter,
             servers,

--- a/query/src/main.rs
+++ b/query/src/main.rs
@@ -11,7 +11,7 @@ mod list_servers;
 mod monitor_servers;
 mod query_servers_info;
 
-use std::{io, process};
+use std::{io, net::SocketAddr, process};
 
 use thiserror::Error;
 use xash3d_observer::{Handler, Observer, ObserverBuilder};
@@ -29,22 +29,47 @@ enum QueryError {
     Io(#[from] io::Error),
 }
 
+fn observer_builder<'a>(cli: &'a Cli) -> ObserverBuilder<'a> {
+    ObserverBuilder::new().filter(&cli.filter)
+}
+
 fn create_observer<T: Handler>(cli: &Cli, handler: T) -> io::Result<Observer<T>> {
-    ObserverBuilder::new()
-        .filter(&cli.filter)
-        .build(handler, cli.masters.as_slice())
+    observer_builder(cli).build(handler, cli.masters.as_slice())
+}
+
+/// Same as [create_observer] but without master servers.
+fn create_observer_no_masters<T: Handler>(cli: &Cli, handler: T) -> io::Result<Observer<T>> {
+    observer_builder(cli).build(handler, &[] as &[&str])
+}
+
+fn parse_server_addresses(servers: &[String]) -> Vec<SocketAddr> {
+    let mut list = Vec::with_capacity(servers.len());
+    for i in servers {
+        match i.parse() {
+            Ok(addr) => list.push(addr),
+            Err(_) => eprintln!("invalid address {i}"),
+        }
+    }
+    if servers.len() != list.len() {
+        process::exit(1);
+    }
+    list.sort_unstable();
+    list.dedup();
+    list
 }
 
 fn execute(cli: Cli) -> Result<(), QueryError> {
     match cli.args.first().map(|s| s.as_str()).unwrap_or_default() {
-        "all" | "" => query_servers_info::run(&cli, &[])?,
+        "all" | "" => query_servers_info::run_all(&cli)?,
         "info" => {
-            if cli.args.len() > 1 {
-                query_servers_info::run(&cli, &cli.args[1..])?;
-            }
+            let list = parse_server_addresses(&cli.args[1..]);
+            query_servers_info::run_custom_servers(&cli, list)?;
         }
         "list" => list_servers::run(&cli)?,
-        "monitor" => monitor_servers::run(&cli)?,
+        "monitor" => {
+            let list = parse_server_addresses(&cli.args[1..]);
+            monitor_servers::run(&cli, list)?;
+        }
         _ => return Err(QueryError::UndefinedCommand),
     }
     Ok(())

--- a/query/src/monitor_servers.rs
+++ b/query/src/monitor_servers.rs
@@ -15,19 +15,25 @@ use crate::{
 
 struct Monitor<'a> {
     cli: &'a Cli,
+    custom_servers: Vec<SocketAddr>,
     servers: HashMap<SocketAddr, ServerInfo>,
 }
 
 impl<'a> Monitor<'a> {
-    fn new(cli: &'a Cli) -> Self {
+    fn new(cli: &'a Cli, custom_servers: Vec<SocketAddr>) -> Self {
         Self {
             cli,
+            custom_servers,
             servers: Default::default(),
         }
     }
 }
 
 impl Handler for Monitor<'_> {
+    fn extra_servers(&mut self) -> &[SocketAddr] {
+        &self.custom_servers
+    }
+
     fn server_update(
         &mut self,
         addr: SocketAddr,
@@ -74,9 +80,14 @@ impl Handler for Monitor<'_> {
     }
 }
 
-pub(crate) fn run(cli: &Cli) -> Result<(), QueryError> {
-    let handler = Monitor::new(cli);
-    let mut observer = crate::create_observer(cli, handler)?;
+pub(crate) fn run(cli: &Cli, servers: Vec<SocketAddr>) -> Result<(), QueryError> {
+    let is_custom_servers = !servers.is_empty();
+    let handler = Monitor::new(cli, servers);
+    let mut observer = if is_custom_servers {
+        crate::create_observer_no_masters(cli, handler)?
+    } else {
+        crate::create_observer(cli, handler)?
+    };
     observer.run()?;
     Ok(())
 }

--- a/query/src/query_servers_info.rs
+++ b/query/src/query_servers_info.rs
@@ -2,12 +2,11 @@ use std::{
     cmp,
     collections::{HashMap, HashSet},
     net::SocketAddr,
-    process,
     time::{Duration, Instant},
 };
 
 use serde::Serialize;
-use xash3d_observer::Handler;
+use xash3d_observer::{Handler, Observer};
 
 use crate::{
     cli::Cli,
@@ -20,8 +19,8 @@ use crate::{
 #[derive(Clone, Debug, Serialize)]
 struct InfoResult<'a> {
     protocol: &'a [u8],
-    master_timeout: u32,
-    server_timeout: u32,
+    master_timeout: u64,
+    server_timeout: u64,
     masters: &'a [Box<str>],
     filter: &'a str,
     servers: &'a [&'a ServerResult],
@@ -31,6 +30,7 @@ struct CollectServerInfo {
     start_time: Instant,
     master_timeout: Duration,
     server_timeout: Duration,
+    is_custom_servers: bool,
     custom_servers: Vec<SocketAddr>,
     servers: HashMap<SocketAddr, ServerResult>,
     pending: HashSet<SocketAddr>,
@@ -38,17 +38,23 @@ struct CollectServerInfo {
 
 impl CollectServerInfo {
     fn new(cli: &Cli, custom_servers: Vec<SocketAddr>) -> Self {
+        let pending = custom_servers.iter().copied().collect();
+
         Self {
             start_time: Instant::now(),
-            master_timeout: Duration::from_secs(cli.master_timeout as u64),
-            server_timeout: Duration::from_secs(cli.server_timeout as u64),
+            master_timeout: cli.master_timeout,
+            server_timeout: cli.server_timeout,
+            is_custom_servers: !custom_servers.is_empty(),
             custom_servers,
-            servers: HashMap::with_capacity(128),
-            pending: HashSet::with_capacity(128),
+            servers: HashMap::new(),
+            pending,
         }
     }
 
     fn insert(&mut self, addr: SocketAddr, result: ServerResult) {
+        // do not fetch info for this server again
+        self.custom_servers.retain(|i| *i != addr);
+
         self.pending.remove(&addr);
         self.servers.insert(addr, result);
     }
@@ -56,26 +62,20 @@ impl CollectServerInfo {
 
 impl Handler for CollectServerInfo {
     fn stop_observer(&mut self) -> bool {
-        if !self.servers.is_empty() && self.pending.is_empty() {
+        // early exit if received results for all custom servers
+        if self.is_custom_servers && !self.servers.is_empty() && self.pending.is_empty() {
             return true;
         }
 
         let mut timeout = self.server_timeout;
-        if self.custom_servers.is_empty() {
+        if !self.is_custom_servers {
             timeout = cmp::max(timeout, self.master_timeout);
-        } else if self.servers.len() == self.custom_servers.len() {
-            return true;
         }
 
         timeout < self.start_time.elapsed()
     }
 
-    fn query_servers_from_master(&mut self, _: SocketAddr) -> bool {
-        self.custom_servers.is_empty()
-    }
-
     fn extra_servers(&mut self) -> &[SocketAddr] {
-        self.pending.extend(&self.custom_servers);
         self.custom_servers.as_slice()
     }
 
@@ -126,8 +126,8 @@ fn print_server_info(cli: &Cli, servers: &[&ServerResult]) {
     if cli.json || cli.debug {
         let result = InfoResult {
             protocol: &cli.protocol,
-            master_timeout: cli.master_timeout,
-            server_timeout: cli.server_timeout,
+            master_timeout: cli.master_timeout.as_secs(),
+            server_timeout: cli.server_timeout.as_secs(),
             masters: &cli.masters,
             filter: &cli.filter,
             servers,
@@ -194,20 +194,7 @@ fn print_server_info(cli: &Cli, servers: &[&ServerResult]) {
     }
 }
 
-pub(crate) fn run(cli: &Cli, servers: &[String]) -> Result<(), QueryError> {
-    let mut custom_servers = Vec::with_capacity(servers.len());
-    for i in servers {
-        match i.parse() {
-            Ok(addr) => custom_servers.push(addr),
-            Err(_) => eprintln!("invalid address {i}"),
-        }
-    }
-    if servers.len() != custom_servers.len() {
-        process::exit(1);
-    }
-
-    let handler = CollectServerInfo::new(cli, custom_servers);
-    let mut observer = crate::create_observer(cli, handler)?;
+fn run(cli: &Cli, mut observer: Observer<CollectServerInfo>) -> Result<(), QueryError> {
     observer.run()?;
     let handler = observer.into_handler();
 
@@ -216,4 +203,19 @@ pub(crate) fn run(cli: &Cli, servers: &[String]) -> Result<(), QueryError> {
     print_server_info(cli, &servers);
 
     Ok(())
+}
+
+pub(crate) fn run_all(cli: &Cli) -> Result<(), QueryError> {
+    let handler = CollectServerInfo::new(cli, Vec::new());
+    let observer = crate::create_observer(cli, handler)?;
+    run(cli, observer)
+}
+
+pub(crate) fn run_custom_servers(cli: &Cli, servers: Vec<SocketAddr>) -> Result<(), QueryError> {
+    if servers.is_empty() {
+        return Ok(());
+    }
+    let handler = CollectServerInfo::new(cli, servers);
+    let observer = crate::create_observer_no_masters(cli, handler)?;
+    run(cli, observer)
 }


### PR DESCRIPTION
`monitor` subcommand can now monitor only custom servers instead of all servers received from master servers.

```
# all servers received from master servers
xash3d-query monitor

# only user provided servers
xash3d-query monitor 127.0.0.1:27015 127.0.0.1:27016
```