### PR TITLE
query: monitor: report ping in json output

### DIFF
--- a/observer/examples/monitor.rs
+++ b/observer/examples/monitor.rs
@@ -101,18 +101,26 @@ impl Handler for Monitor {
         let info = ServerInfo::new(info);
         match self.servers.entry(addr) {
             Entry::Occupied(mut e) => {
-                println!("{:24?} --- {:>7.1} {}", addr, ' ', e.get());
-                println!("{addr:24?} +++ {ping:>7.1?} {info}");
+                println!("{:8} {addr:24?} {ping:>7.1?} {info}", "update");
                 e.insert(info);
             }
             Entry::Vacant(e) => {
-                println!("{addr:24?} +++ {ping:>7.1?} {info}");
+                println!("{:8} {addr:24?} {ping:>7.1?} {info}", "new");
                 e.insert(info);
             }
         }
     }
 
+    fn server_update_ping(&mut self, addr: SocketAddr, ping: Duration) {
+        println!("{:8} {addr:24?} {ping:>7.1?}", "ping");
+    }
+
+    fn server_timeout(&mut self, addr: SocketAddr) {
+        println!("{:8} {addr:24?}", "timeout");
+    }
+
     fn server_remove(&mut self, addr: SocketAddr) {
+        println!("{:8} {addr:24?}", "remove");
         self.servers.remove(&addr);
     }
 }

--- a/observer/src/lib.rs
+++ b/observer/src/lib.rs
@@ -115,6 +115,9 @@ pub trait Handler {
     ) {
     }
 
+    /// Called if a server info does not changed.
+    fn server_update_ping(&mut self, addr: SocketAddr, ping: Duration) {}
+
     /// Called if a server removed from a query list.
     fn server_remove(&mut self, addr: SocketAddr) {}
 
@@ -452,10 +455,12 @@ impl<T: Handler> Observer<T> {
                 if let Some(con) = self.connections.get_mut(&from) {
                     match con.state {
                         S::ProtocolDetection | S::WaitingInfo => {
+                            let ping = con.ping(self.now);
                             if con.is_changed(buf) {
                                 let is_new = con.state == S::ProtocolDetection;
-                                let ping = con.ping(self.now);
                                 self.handler.server_update(from, &packet, is_new, ping);
+                            } else {
+                                self.handler.server_update_ping(from, ping);
                             }
                             con.state = S::Idle;
                         }

--- a/query/src/monitor_servers.rs
+++ b/query/src/monitor_servers.rs
@@ -63,6 +63,13 @@ impl Handler for Monitor<'_> {
         }
     }
 
+    fn server_update_ping(&mut self, addr: SocketAddr, ping: Duration) {
+        if self.cli.json {
+            let result = ServerResult::ping(addr, ping);
+            println!("{}", serde_json::to_string_pretty(&result).unwrap());
+        }
+    }
+
     fn server_timeout(&mut self, addr: SocketAddr) {
         if self.cli.json {
             let result = ServerResult::timeout(addr);

--- a/query/src/query_servers_info.rs
+++ b/query/src/query_servers_info.rs
@@ -170,6 +170,7 @@ fn print_server_info(cli: &Cli, servers: &[&ServerResult]) {
                         password: info.password,
                     }
                 }
+                ServerResultKind::Ping => unreachable!(),
                 ServerResultKind::Timeout => {
                     p! {
                         status: "timeout",

--- a/query/src/server_result.rs
+++ b/query/src/server_result.rs
@@ -17,6 +17,7 @@ pub enum ServerResultKind {
         #[serde(flatten)]
         info: ServerInfo,
     },
+    Ping,
     InvalidPacket {
         message: String,
         response: String,
@@ -50,6 +51,10 @@ impl ServerResult {
 
     pub fn ok(address: SocketAddr, ping: Duration, info: ServerInfo) -> Self {
         Self::new(address, Some(ping), ServerResultKind::Ok { info })
+    }
+
+    pub fn ping(address: SocketAddr, ping: Duration) -> Self {
+        Self::new(address, Some(ping), ServerResultKind::Ping)
     }
 
     pub fn timeout(address: SocketAddr) -> Self {


### PR DESCRIPTION
Add ping reports to query-monitor when outputting json.

```
$ xash3d-query monitor --json
...
{
  "time": 1775904874,
  "address": "127.0.0.1:27015",
  "ping": 123.456,
  "status": "ping"
}
...
```