### PR TITLE
query: improve all|info subcommand output

### DIFF
--- a/query/src/cli.rs
+++ b/query/src/cli.rs
@@ -8,8 +8,10 @@ use std::{
     time::Duration,
 };
 
-use getopts::Options;
+#[cfg(feature = "color")]
+use std::io;
 
+use getopts::Options;
 use xash3d_protocol::{self as proto, filter::Version};
 
 const BIN_NAME: &str = env!("CARGO_BIN_NAME");
@@ -123,11 +125,12 @@ pub struct Cli {
     pub master_timeout: Duration,
     pub server_timeout: Duration,
     pub protocol: Vec<u8>,
+    pub all_servers: bool,
     pub players: bool,
     pub compact: bool,
     pub json: bool,
     pub debug: bool,
-    pub force_color: bool,
+    force_color: bool,
     pub filter: String,
 }
 
@@ -142,6 +145,7 @@ impl Default for Cli {
             master_timeout: Duration::from_secs(2),
             server_timeout: Duration::from_secs(2),
             protocol: vec![proto::PROTOCOL_VERSION, proto::PROTOCOL_VERSION - 1],
+            all_servers: false,
             players: true,
             compact: false,
             json: false,
@@ -149,6 +153,21 @@ impl Default for Cli {
             force_color: false,
             filter: String::new(),
         }
+    }
+}
+
+impl Cli {
+    pub fn colored_output(&self) -> bool {
+        if self.force_color {
+            return true;
+        }
+
+        #[cfg(feature = "color")]
+        if crossterm::tty::IsTty::is_tty(&io::stdout()) {
+            return true;
+        }
+
+        false
     }
 }
 
@@ -201,6 +220,7 @@ pub fn parse() -> Cli {
         .join(",");
     let help = format!("protocol version [default: {protocols}]");
     opts.optopt("p", "protocol", &help, "VERSION");
+    opts.optflag("A", "all-servers", "print all servers");
     opts.optflag(
         "c",
         "compact-output",
@@ -294,6 +314,7 @@ pub fn parse() -> Cli {
     }
 
     cli.filter = filter.opt_get(&matches);
+    cli.all_servers = matches.opt_present("all-servers");
     cli.compact = matches.opt_present("compact-output");
     cli.players = !matches.opt_present("no-players");
     cli.json = matches.opt_present("json");

--- a/query/src/color.rs
+++ b/query/src/color.rs
@@ -1,16 +1,13 @@
 use std::fmt;
 
-#[cfg(feature = "color")]
-use std::io;
-
 pub struct Colored<'a> {
-    inner: &'a str,
-    forced: bool,
+    text: &'a str,
+    enable: bool,
 }
 
 impl<'a> Colored<'a> {
-    pub fn new(s: &'a str, forced: bool) -> Self {
-        Self { inner: s, forced }
+    pub fn new(text: &'a str, enable: bool) -> Self {
+        Self { text, enable }
     }
 }
 
@@ -18,15 +15,14 @@ impl fmt::Display for Colored<'_> {
     fn fmt(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
         use xash3d_protocol::color;
 
-        #[cfg(feature = "color")]
-        use crossterm::{style::Stylize, tty::IsTty};
-
         // TODO: unicode width
         let mut width = 0;
-        let mut iter = color::ColorIter::new(self.inner);
+        let mut iter = color::ColorIter::new(self.text);
 
         #[cfg(feature = "color")]
-        if self.forced || io::stdout().is_tty() {
+        if self.enable {
+            use crossterm::style::Stylize;
+
             for (color, text) in iter.by_ref() {
                 width += text.chars().count();
                 let colored = match color::Color::try_from(color) {

--- a/query/src/query_servers_info.rs
+++ b/query/src/query_servers_info.rs
@@ -1,5 +1,6 @@
 use std::{
     collections::{hash_map::Entry, HashMap, HashSet},
+    fmt,
     net::SocketAddr,
     time::{Duration, Instant},
 };
@@ -27,17 +28,70 @@ struct InfoResult<'a> {
     servers: &'a [ServerResult],
 }
 
+const LABEL_WIDTH: usize = 10;
+
+struct Label {
+    text: &'static str,
+    colored_output: bool,
+}
+
+impl fmt::Display for Label {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        #[cfg(feature = "color")]
+        if self.colored_output {
+            use crossterm::style::Stylize;
+            // Align manually because StyledContent printer does not support width parameter.
+            if let Some(n) = LABEL_WIDTH.checked_sub(self.text.len()) {
+                write!(f, "{:n$}", "")?;
+            }
+
+            return write!(f, "{}", self.text.bold().green());
+        }
+
+        write!(f, "{:>LABEL_WIDTH$}", self.text)
+    }
+}
+
 struct Printer<'a> {
+    all_servers: bool,
+    colored_output: bool,
     servers: &'a [ServerResult],
     /// Temporary storage for players.
     players: Vec<&'a PlayerInfo>,
 }
 
 impl<'a> Printer<'a> {
-    fn new(servers: &'a [ServerResult]) -> Self {
+    fn new(cli: &Cli, custom: bool, servers: &'a [ServerResult]) -> Self {
         Self {
+            all_servers: custom || cli.all_servers,
+            colored_output: cli.colored_output(),
             servers,
             players: Vec::new(),
+        }
+    }
+
+    fn label(&self, text: &'static str) -> Label {
+        Label {
+            colored_output: self.colored_output,
+            text,
+        }
+    }
+
+    fn label_server(&self, address: SocketAddr) -> impl fmt::Display {
+        struct LabelServer {
+            label: Label,
+            address: SocketAddr,
+        }
+
+        impl fmt::Display for LabelServer {
+            fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+                write!(f, "{}: {}", self.label, self.address)
+            }
+        }
+
+        LabelServer {
+            label: self.label("server"),
+            address,
         }
     }
 
@@ -60,17 +114,8 @@ impl<'a> Printer<'a> {
         }
     }
 
-    fn print_server(&mut self, cli: &Cli, i: usize, server: &'a ServerResult) {
-        let ServerResultKind::Ok { info } = &server.kind else {
-            return;
-        };
-
-        if i > 0 {
-            println!();
-        }
-
-        let w = 10;
-        print!("{:>w$}: {}", "server", server.address);
+    fn print_server_info(&mut self, cli: &Cli, server: &ServerResult, info: &ServerInfo) {
+        print!("{}", self.label_server(server.address));
         if let Some(ping) = server.ping_millis_f32() {
             print!(" [ping {ping:.0}ms]");
         }
@@ -82,12 +127,12 @@ impl<'a> Printer<'a> {
         }
         println!();
 
-        let host = Colored::new(&info.host, cli.force_color);
-        println!("{:>w$}: {}", "name", host);
-        println!("{:>w$}: {}", "game", info.gamedir);
-        println!("{:>w$}: {}", "map", info.map);
+        let host = Colored::new(info.host.trim(), cli.colored_output());
+        println!("{}: {}", self.label("name"), host);
+        println!("{}: {}", self.label("game"), info.gamedir.trim());
+        println!("{}: {}", self.label("map"), info.map.trim());
 
-        print!("{:>w$}:", "mode");
+        print!("{}:", self.label("mode"));
         if info.coop || info.team || info.dm {
             if info.coop {
                 print!(" coop");
@@ -103,17 +148,33 @@ impl<'a> Printer<'a> {
         }
         println!();
 
-        println!("{:>w$}: {}/{}", "players", info.numcl, info.maxcl);
+        println!("{}: {}/{}", self.label("players"), info.numcl, info.maxcl);
+    }
 
-        if !info.players.is_empty() {
-            self.players.clear();
-            self.players.extend(info.players.iter());
-            self.players.sort_by_key(|i| i.frags);
-            for (i, player) in self.players.iter().rev().enumerate() {
-                let name = Colored::new(&player.name, cli.force_color);
-                println!("{i:w$}: {} {name}", player.frags);
-            }
+    fn print_server_players(&mut self, cli: &Cli, players: &'a Players) {
+        if players.is_empty() {
+            return;
         }
+
+        self.players.clear();
+        self.players.extend(players.iter());
+        self.players.sort_by_key(|i| i.frags);
+        for (i, player) in self.players.iter().rev().enumerate() {
+            let name = Colored::new(&player.name, cli.colored_output());
+            println!("{i:>LABEL_WIDTH$}: {} {name}", player.frags);
+        }
+    }
+
+    fn print_timeout(&mut self, _: &Cli, server: &ServerResult) {
+        println!("{} [timeout]", self.label_server(server.address));
+    }
+
+    fn print_invalid_protocol(&mut self, _: &Cli, server: &ServerResult) {
+        println!("{} [protocol error]", self.label_server(server.address));
+    }
+
+    fn print_invalid_packet(&mut self, _: &Cli, server: &ServerResult) {
+        println!("{} [invalid]", self.label_server(server.address));
     }
 
     fn print(&mut self, cli: &Cli) {
@@ -122,8 +183,40 @@ impl<'a> Printer<'a> {
             return;
         }
 
-        for (i, server) in self.servers.iter().enumerate() {
-            self.print_server(cli, i, server);
+        let mut first = true;
+        let mut print_separator = || {
+            if first {
+                first = false;
+            } else {
+                println!();
+            }
+        };
+
+        for server in self.servers {
+            match &server.kind {
+                ServerResultKind::Ok { info } => {
+                    print_separator();
+                    self.print_server_info(cli, server, info);
+                }
+                ServerResultKind::OkWithPlayers { info, players } => {
+                    print_separator();
+                    self.print_server_info(cli, server, info);
+                    self.print_server_players(cli, players);
+                }
+                ServerResultKind::Timeout if self.all_servers => {
+                    print_separator();
+                    self.print_timeout(cli, server);
+                }
+                ServerResultKind::InvalidProtocol if self.all_servers => {
+                    print_separator();
+                    self.print_invalid_protocol(cli, server);
+                }
+                ServerResultKind::InvalidPacket { .. } if self.all_servers => {
+                    print_separator();
+                    self.print_invalid_packet(cli, server);
+                }
+                _ => {}
+            }
         }
     }
 }
@@ -248,7 +341,7 @@ impl QueryServersInfo {
 
         let mut servers: Vec<_> = self.servers.into_values().collect();
         servers.sort_by_key(|a| a.address);
-        Printer::new(&servers).print(cli);
+        Printer::new(cli, self.custom, &servers).print(cli);
 
         Ok(())
     }

--- a/query/src/server_info.rs
+++ b/query/src/server_info.rs
@@ -70,8 +70,6 @@ pub struct ServerInfo {
     pub coop: bool,
     pub password: bool,
     pub dedicated: bool,
-    #[serde(flatten)]
-    pub players: Players,
 }
 
 impl ServerInfo {
@@ -94,7 +92,6 @@ impl From<&xash3d_observer::event::ServerInfo<'_>> for ServerInfo {
             coop: other.is_coop(),
             password: other.has_password(),
             dedicated: other.is_dedicated(),
-            players: Players::default(),
         }
     }
 }
@@ -124,9 +121,9 @@ impl fmt::Display for ServerInfoPrinter<'_> {
             flag('D', self.info.dedicated),
             self.info.numcl,
             self.info.maxcl,
-            self.info.gamedir,
-            self.info.map,
-            Colored::new(&self.info.host, self.cli.force_color),
+            self.info.gamedir.trim(),
+            self.info.map.trim(),
+            Colored::new(self.info.host.trim(), self.cli.colored_output()),
         )
     }
 }

--- a/query/src/server_result.rs
+++ b/query/src/server_result.rs
@@ -16,6 +16,12 @@ pub enum ServerResultKind {
         #[serde(flatten)]
         info: ServerInfo,
     },
+    OkWithPlayers {
+        #[serde(flatten)]
+        info: ServerInfo,
+        #[serde(flatten)]
+        players: Players,
+    },
     Ping,
     InvalidPacket {
         data: Vec<u8>,
@@ -88,11 +94,13 @@ impl ServerResult {
     }
 
     pub fn set_players(&mut self, players: Players) {
-        if let ServerResultKind::Ok { info } = &mut self.kind {
-            info.players = players;
+        let mut kind = mem::replace(&mut self.kind, ServerResultKind::Timeout);
+        if let ServerResultKind::Ok { info } = kind {
+            kind = ServerResultKind::OkWithPlayers { info, players };
         } else {
             self.players = Some(players);
         }
+        self.kind = kind;
     }
 
     pub fn is_ok(&self) -> bool {
@@ -103,15 +111,17 @@ impl ServerResult {
         self.players.is_some()
     }
 
-    pub fn set_ok(&mut self, ping: Duration, mut info: ServerInfo) {
-        let kind = mem::replace(&mut self.kind, ServerResultKind::Timeout);
-        if let ServerResultKind::Ok { info: old } = kind {
-            info.players = old.players;
+    pub fn set_ok(&mut self, ping: Duration, info: ServerInfo) {
+        let mut kind = mem::replace(&mut self.kind, ServerResultKind::Timeout);
+        if let ServerResultKind::OkWithPlayers { players, .. } = kind {
+            kind = ServerResultKind::OkWithPlayers { info, players };
         } else if let Some(players) = self.players.take() {
-            info.players = players;
+            kind = ServerResultKind::OkWithPlayers { info, players };
+        } else {
+            kind = ServerResultKind::Ok { info };
         }
         self.ping = Some(ping);
-        self.kind = ServerResultKind::Ok { info };
+        self.kind = kind;
     }
 }
 


### PR DESCRIPTION
* Add -A|--all option to always output all servers.
* Trim host, gamedir and map strings.
* Add colored labels. <img width="577" height="282" alt="image" src="https://github.com/user-attachments/assets/7123791f-2200-4e2c-b294-13fd868ed56d" />
* `info` subcommand output results for all requested servers. <img width="580" height="104" alt="image" src="https://github.com/user-attachments/assets/605b36d1-e44c-44cc-b38b-73784da6171a" />