### PR TITLE
master: add stateless challenge generator, migrate away from challenges pool

### DIFF
--- a/crates/xash3d-master/config/default.toml
+++ b/crates/xash3d-master/config/default.toml
@@ -19,6 +19,9 @@
 # Set 0 to disable.
 #client-rate-limit = 0
 
+# Challenge time window, in seconds.
+#challenge-window = 60
+
 [server.timeout]
 # Time in seconds while challenge is valid
 #challenge = 10

--- a/crates/xash3d-master/src/challenge.rs
+++ b/crates/xash3d-master/src/challenge.rs
@@ -1,0 +1,148 @@
+//! Stateless challenges for source-address verification.
+//!
+//! Copies the pattern from engine's `SV_GetChallenge`: the challenge is derived
+//! from src address, a salt generated at master startup, and a time window.
+//! Validation accepts the current and previous window so
+//! requests near the boundary still succeed.
+
+use std::net::{IpAddr, SocketAddr};
+use std::sync::OnceLock;
+use std::time::Instant;
+
+use blake2b_simd::Params;
+use fastrand::Rng;
+
+/// Per-master secret used to derive challenges.
+#[derive(Clone)]
+pub struct ChallengeKey {
+    salt: [u8; 16],
+}
+
+impl ChallengeKey {
+    pub fn random(rng: &mut Rng) -> Self {
+        let mut salt = [0u8; 16];
+        rng.fill(&mut salt);
+        Self { salt }
+    }
+
+    pub fn compute(&self, addr: SocketAddr, time_window: u64) -> u32 {
+        let mut state = Params::new().hash_length(4).to_state();
+        match addr.ip() {
+            IpAddr::V4(v4) => {
+                state.update(&v4.octets());
+            }
+            IpAddr::V6(v6) => {
+                state.update(&v6.octets());
+            }
+        }
+        state.update(&addr.port().to_ne_bytes());
+        state.update(&self.salt);
+        state.update(&time_window.to_ne_bytes());
+        let hash = state.finalize();
+        let b = hash.as_bytes();
+        u32::from_le_bytes([b[0], b[1], b[2], b[3]])
+    }
+
+    pub fn validate(&self, addr: SocketAddr, time_window: u64, challenge: u32) -> bool {
+        self.compute(addr, time_window) == challenge
+            || self.compute(addr, time_window.wrapping_sub(1)) == challenge
+    }
+}
+
+/// Returns the current time window index
+pub fn current_time_window(window_secs: u64) -> u64 {
+    static BASE: OnceLock<Instant> = OnceLock::new();
+    let base = BASE.get_or_init(Instant::now);
+    Instant::now().duration_since(*base).as_secs() / window_secs
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn fixed_key() -> ChallengeKey {
+        ChallengeKey {
+            salt: *b"0123456789abcdef",
+        }
+    }
+
+    fn addr(s: &str) -> SocketAddr {
+        s.parse().unwrap()
+    }
+
+    #[test]
+    fn deterministic() {
+        let k = fixed_key();
+        let a = addr("192.0.2.1:27015");
+        assert_eq!(k.compute(a, 1000), k.compute(a, 1000));
+    }
+
+    #[test]
+    fn ip_sensitive() {
+        let k = fixed_key();
+        assert_ne!(
+            k.compute(addr("1.2.3.4:27015"), 1000),
+            k.compute(addr("1.2.3.5:27015"), 1000),
+        );
+    }
+
+    #[test]
+    fn port_sensitive() {
+        let k = fixed_key();
+        assert_ne!(
+            k.compute(addr("1.2.3.4:27015"), 1000),
+            k.compute(addr("1.2.3.4:27016"), 1000),
+        );
+    }
+
+    #[test]
+    fn window_sensitive() {
+        let k = fixed_key();
+        let a = addr("1.2.3.4:27015");
+        assert_ne!(k.compute(a, 1000), k.compute(a, 1001));
+    }
+
+    #[test]
+    fn salt_sensitive() {
+        let mut rng = Rng::with_seed(42);
+        let a = ChallengeKey::random(&mut rng);
+        let b = ChallengeKey::random(&mut rng);
+        let src = addr("1.2.3.4:27015");
+        assert_ne!(a.compute(src, 1000), b.compute(src, 1000));
+    }
+
+    #[test]
+    fn validate_current_and_previous_window() {
+        let k = fixed_key();
+        let a = addr("10.0.0.1:27015");
+        let now = 1000;
+        let c_now = k.compute(a, now);
+        let c_prev = k.compute(a, now - 1);
+        assert!(k.validate(a, now, c_now));
+        assert!(k.validate(a, now, c_prev));
+        assert!(!k.validate(a, now, c_now.wrapping_add(1)));
+    }
+
+    #[test]
+    fn validate_rejects_two_windows_old() {
+        let k = fixed_key();
+        let a = addr("10.0.0.1:27015");
+        let stale = k.compute(a, 998);
+        assert!(!k.validate(a, 1000, stale));
+    }
+
+    #[test]
+    fn validate_rejects_different_port() {
+        let k = fixed_key();
+        let c = k.compute(addr("10.0.0.1:27015"), 1000);
+        assert!(!k.validate(addr("10.0.0.1:27016"), 1000, c));
+    }
+
+    #[test]
+    fn ipv6_works() {
+        let k = fixed_key();
+        let a = addr("[2001:db8::1]:27015");
+        let c = k.compute(a, 1000);
+        assert!(k.validate(a, 1000, c));
+    }
+}

--- a/crates/xash3d-master/src/challenge.rs
+++ b/crates/xash3d-master/src/challenge.rs
@@ -5,12 +5,72 @@
 //! Validation accepts the current and previous window so
 //! requests near the boundary still succeed.
 
-use std::net::{IpAddr, SocketAddr};
-use std::sync::OnceLock;
-use std::time::Instant;
+use std::{
+    net::{IpAddr, Ipv4Addr, Ipv6Addr, SocketAddr},
+    sync::OnceLock,
+    time::Instant,
+};
 
-use blake2b_simd::Params;
+use blake2b_simd::{Params, State};
 use fastrand::Rng;
+
+/// A target for challenge.
+pub trait Target {
+    fn update_state(&self, state: &mut State);
+}
+
+impl Target for Ipv4Addr {
+    fn update_state(&self, state: &mut State) {
+        state.update(&self.octets());
+    }
+}
+
+impl Target for Ipv6Addr {
+    fn update_state(&self, state: &mut State) {
+        state.update(&self.octets());
+    }
+}
+
+impl Target for IpAddr {
+    fn update_state(&self, state: &mut State) {
+        match self {
+            IpAddr::V4(v4) => v4.update_state(state),
+            IpAddr::V6(v6) => v6.update_state(state),
+        }
+    }
+}
+
+impl Target for SocketAddr {
+    fn update_state(&self, state: &mut State) {
+        self.ip().update_state(state);
+        state.update(&self.port().to_ne_bytes());
+    }
+}
+
+/// Create a challenge from hash.
+pub trait Challenge: PartialEq {
+    const HASH_SIZE: usize;
+
+    fn from_hash(hash: &[u8]) -> Self;
+}
+
+impl Challenge for u32 {
+    const HASH_SIZE: usize = 4;
+
+    fn from_hash(hash: &[u8]) -> Self {
+        u32::from_le_bytes([hash[0], hash[1], hash[2], hash[3]])
+    }
+}
+
+impl<A: Challenge, B: Challenge> Challenge for (A, B) {
+    const HASH_SIZE: usize = A::HASH_SIZE + B::HASH_SIZE;
+
+    fn from_hash(hash: &[u8]) -> Self {
+        let (a, tail) = hash.split_at(A::HASH_SIZE);
+        let b = &tail[..B::HASH_SIZE];
+        (A::from_hash(a), B::from_hash(b))
+    }
+}
 
 /// Per-master secret used to derive challenges.
 #[derive(Clone)]
@@ -25,35 +85,42 @@ impl ChallengeKey {
         Self { salt }
     }
 
-    pub fn compute(&self, addr: SocketAddr, time_window: u64) -> u32 {
-        let mut state = Params::new().hash_length(4).to_state();
-        match addr.ip() {
-            IpAddr::V4(v4) => {
-                state.update(&v4.octets());
-            }
-            IpAddr::V6(v6) => {
-                state.update(&v6.octets());
-            }
-        }
-        state.update(&addr.port().to_ne_bytes());
+    pub fn compute<T: Target, C: Challenge>(&self, target: &T, time_window: u64) -> C {
+        let mut state = Params::new().hash_length(C::HASH_SIZE).to_state();
+        target.update_state(&mut state);
         state.update(&self.salt);
         state.update(&time_window.to_ne_bytes());
         let hash = state.finalize();
-        let b = hash.as_bytes();
-        u32::from_le_bytes([b[0], b[1], b[2], b[3]])
+        C::from_hash(&hash.as_bytes()[..C::HASH_SIZE])
     }
 
-    pub fn validate(&self, addr: SocketAddr, time_window: u64, challenge: u32) -> bool {
-        self.compute(addr, time_window) == challenge
-            || self.compute(addr, time_window.wrapping_sub(1)) == challenge
+    pub fn compute_u32<T: Target>(&self, target: &T, time_window: u64) -> u32 {
+        self.compute::<T, u32>(target, time_window)
+    }
+
+    pub fn compute_u32_pair<T: Target>(&self, target: &T, time_window: u64) -> (u32, u32) {
+        self.compute::<T, (u32, u32)>(target, time_window)
+    }
+
+    pub fn validate<T: Target, C: Challenge>(
+        &self,
+        target: &T,
+        time_window: u64,
+        challenge: C,
+    ) -> bool {
+        self.compute::<T, C>(target, time_window) == challenge
+            || self.compute::<T, C>(target, time_window.wrapping_sub(1)) == challenge
+    }
+
+    pub fn validate_u32<T: Target>(&self, target: &T, time_window: u64, challenge: u32) -> bool {
+        self.validate(target, time_window, challenge)
     }
 }
 
 /// Returns the current time window index
 pub fn current_time_window(window_secs: u64) -> u64 {
     static BASE: OnceLock<Instant> = OnceLock::new();
-    let base = BASE.get_or_init(Instant::now);
-    Instant::now().duration_since(*base).as_secs() / window_secs
+    BASE.get_or_init(Instant::now).elapsed().as_secs() / window_secs
 }
 
 #[cfg(test)]
@@ -73,16 +140,16 @@ mod tests {
     #[test]
     fn deterministic() {
         let k = fixed_key();
-        let a = addr("192.0.2.1:27015");
-        assert_eq!(k.compute(a, 1000), k.compute(a, 1000));
+        let a = &addr("192.0.2.1:27015");
+        assert_eq!(k.compute_u32(a, 1000), k.compute_u32(a, 1000));
     }
 
     #[test]
     fn ip_sensitive() {
         let k = fixed_key();
         assert_ne!(
-            k.compute(addr("1.2.3.4:27015"), 1000),
-            k.compute(addr("1.2.3.5:27015"), 1000),
+            k.compute_u32(&addr("1.2.3.4:27015"), 1000),
+            k.compute_u32(&addr("1.2.3.5:27015"), 1000),
         );
     }
 
@@ -90,16 +157,16 @@ mod tests {
     fn port_sensitive() {
         let k = fixed_key();
         assert_ne!(
-            k.compute(addr("1.2.3.4:27015"), 1000),
-            k.compute(addr("1.2.3.4:27016"), 1000),
+            k.compute_u32(&addr("1.2.3.4:27015"), 1000),
+            k.compute_u32(&addr("1.2.3.4:27016"), 1000),
         );
     }
 
     #[test]
     fn window_sensitive() {
         let k = fixed_key();
-        let a = addr("1.2.3.4:27015");
-        assert_ne!(k.compute(a, 1000), k.compute(a, 1001));
+        let a = &addr("1.2.3.4:27015");
+        assert_ne!(k.compute_u32(a, 1000), k.compute(a, 1001));
     }
 
     #[test]
@@ -107,42 +174,42 @@ mod tests {
         let mut rng = Rng::with_seed(42);
         let a = ChallengeKey::random(&mut rng);
         let b = ChallengeKey::random(&mut rng);
-        let src = addr("1.2.3.4:27015");
-        assert_ne!(a.compute(src, 1000), b.compute(src, 1000));
+        let src = &addr("1.2.3.4:27015");
+        assert_ne!(a.compute_u32(src, 1000), b.compute(src, 1000));
     }
 
     #[test]
     fn validate_current_and_previous_window() {
         let k = fixed_key();
-        let a = addr("10.0.0.1:27015");
+        let a = &addr("10.0.0.1:27015");
         let now = 1000;
-        let c_now = k.compute(a, now);
-        let c_prev = k.compute(a, now - 1);
-        assert!(k.validate(a, now, c_now));
-        assert!(k.validate(a, now, c_prev));
-        assert!(!k.validate(a, now, c_now.wrapping_add(1)));
+        let c_now = k.compute_u32(a, now);
+        let c_prev = k.compute_u32(a, now - 1);
+        assert!(k.validate_u32(a, now, c_now));
+        assert!(k.validate_u32(a, now, c_prev));
+        assert!(!k.validate_u32(a, now, c_now.wrapping_add(1)));
     }
 
     #[test]
     fn validate_rejects_two_windows_old() {
         let k = fixed_key();
-        let a = addr("10.0.0.1:27015");
-        let stale = k.compute(a, 998);
-        assert!(!k.validate(a, 1000, stale));
+        let a = &addr("10.0.0.1:27015");
+        let stale = k.compute_u32(a, 998);
+        assert!(!k.validate_u32(a, 1000, stale));
     }
 
     #[test]
     fn validate_rejects_different_port() {
         let k = fixed_key();
-        let c = k.compute(addr("10.0.0.1:27015"), 1000);
-        assert!(!k.validate(addr("10.0.0.1:27016"), 1000, c));
+        let c = k.compute_u32(&addr("10.0.0.1:27015"), 1000);
+        assert!(!k.validate_u32(&addr("10.0.0.1:27016"), 1000, c));
     }
 
     #[test]
     fn ipv6_works() {
         let k = fixed_key();
-        let a = addr("[2001:db8::1]:27015");
-        let c = k.compute(a, 1000);
-        assert!(k.validate(a, 1000, c));
+        let a = &addr("[2001:db8::1]:27015");
+        let c = k.compute_u32(a, 1000);
+        assert!(k.validate_u32(a, 1000, c));
     }
 }

--- a/crates/xash3d-master/src/challenge.rs
+++ b/crates/xash3d-master/src/challenge.rs
@@ -6,7 +6,7 @@
 //! requests near the boundary still succeed.
 
 use std::{
-    net::{IpAddr, Ipv4Addr, Ipv6Addr, SocketAddr},
+    net::{IpAddr, Ipv4Addr, Ipv6Addr, SocketAddr, SocketAddrV4, SocketAddrV6},
     sync::OnceLock,
     time::Instant,
 };
@@ -40,10 +40,26 @@ impl Target for IpAddr {
     }
 }
 
-impl Target for SocketAddr {
+impl Target for SocketAddrV4 {
     fn update_state(&self, state: &mut State) {
         self.ip().update_state(state);
         state.update(&self.port().to_ne_bytes());
+    }
+}
+
+impl Target for SocketAddrV6 {
+    fn update_state(&self, state: &mut State) {
+        self.ip().update_state(state);
+        state.update(&self.port().to_ne_bytes());
+    }
+}
+
+impl Target for SocketAddr {
+    fn update_state(&self, state: &mut State) {
+        match self {
+            SocketAddr::V4(v4) => v4.update_state(state),
+            SocketAddr::V6(v6) => v6.update_state(state),
+        }
     }
 }
 
@@ -96,10 +112,6 @@ impl ChallengeKey {
 
     pub fn compute_u32<T: Target>(&self, target: &T, time_window: u64) -> u32 {
         self.compute::<T, u32>(target, time_window)
-    }
-
-    pub fn compute_u32_pair<T: Target>(&self, target: &T, time_window: u64) -> (u32, u32) {
-        self.compute::<T, (u32, u32)>(target, time_window)
     }
 
     pub fn validate<T: Target, C: Challenge>(

--- a/crates/xash3d-master/src/config.rs
+++ b/crates/xash3d-master/src/config.rs
@@ -95,6 +95,7 @@ pub struct ServerConfig {
     pub min_version: Version,
     pub timeout: TimeoutConfig,
     pub client_rate_limit: u32,
+    pub challenge_window: u64,
 }
 
 impl Default for ServerConfig {
@@ -106,6 +107,7 @@ impl Default for ServerConfig {
             min_version: DEFAULT_SERVER_MIN_VERSION,
             timeout: Default::default(),
             client_rate_limit: 0,
+            challenge_window: 60,
         }
     }
 }

--- a/crates/xash3d-master/src/main.rs
+++ b/crates/xash3d-master/src/main.rs
@@ -2,6 +2,7 @@
 extern crate log;
 
 mod app;
+mod challenge;
 mod cli;
 mod config;
 mod hash_map;

--- a/crates/xash3d-master/src/udp_server.rs
+++ b/crates/xash3d-master/src/udp_server.rs
@@ -28,6 +28,7 @@ use xash3d_protocol::{
 };
 
 use crate::{
+    challenge::{self, ChallengeKey},
     config::{Config, MasterConfig},
     hash_map::{Timed, TimedHashMap},
     signals::SignalFlags,
@@ -241,8 +242,8 @@ struct UdpServerState<Addr: AddrExt> {
 
     blocklist: RwLock<HashSet<Addr::Ip>>,
 
-    challenges: RwLock<TimedHashMap<Addr, u32>>,
     servers: RwLock<TimedHashMap<Addr, ServerInfo>>,
+    challenge_key: ChallengeKey,
 
     admin_challenges: RwLock<TimedHashMap<Addr::Ip, (u32, u32)>>,
     // rate limit if hash is invalid
@@ -256,11 +257,12 @@ impl<Addr: AddrExt> UdpServerState<Addr> {
     fn new(cfg: &Config, addr: &Addr) -> Self {
         let update_addr = resolve_update_addr(&cfg.master, addr.wrap());
         let timeout = &cfg.master.server.timeout;
+        let challenge_key = ChallengeKey::random(&mut Rng::new());
         Self {
             update_addr: RwLock::new(update_addr),
             blocklist: Default::default(),
-            challenges: RwLock::new(TimedHashMap::new(timeout.challenge)),
             servers: RwLock::new(TimedHashMap::new(timeout.server)),
+            challenge_key,
             admin_challenges: RwLock::new(TimedHashMap::new(timeout.challenge)),
             admin_limit: RwLock::new(TimedHashMap::new(timeout.admin)),
             update_gamedir: RwLock::new(TimedHashMap::new(5)),
@@ -273,10 +275,6 @@ impl<Addr: AddrExt> UdpServerState<Addr> {
 
         // set timeouts from new config
         let timeout = &cfg.master.server.timeout;
-        self.challenges
-            .write()
-            .unwrap()
-            .set_timeout(timeout.challenge);
         self.servers.write().unwrap().set_timeout(timeout.server);
         self.admin_challenges
             .write()
@@ -286,7 +284,6 @@ impl<Addr: AddrExt> UdpServerState<Addr> {
     }
 
     fn clear(&self) {
-        self.challenges.write().unwrap().clear();
         self.servers.write().unwrap().clear();
         self.admin_challenges.write().unwrap().clear();
         self.admin_limit.write().unwrap().clear();
@@ -429,7 +426,8 @@ impl<Addr: AddrExt> UdpServerGeneric<Addr> {
         from: &Addr,
         msg: &server::Challenge,
     ) -> Result<(), UdpServerError> {
-        let challenge = self.server_challenge_add(*from);
+        let window = challenge::current_time_window(self.cfg.server.challenge_window);
+        let challenge = self.state.challenge_key.compute(from.wrap(), window);
         let resp = master::ChallengeResponse::new(challenge, msg.server_challenge);
         trace!("{from}: send {resp:?}");
         let mut buf = [0; 32];
@@ -449,16 +447,16 @@ impl<Addr: AddrExt> UdpServerGeneric<Addr> {
             warn!("{from}: server version is {ver} but minimal allowed is {min}",);
             return Ok(());
         }
-        let Some(challenge) = self.server_challenge_get(from) else {
-            trace!("{from}: challenge does not exist");
-            return Ok(());
-        };
-        if msg.challenge != challenge {
+        let window = challenge::current_time_window(self.cfg.server.challenge_window);
+        let valid = self
+            .state
+            .challenge_key
+            .validate(from.wrap(), window, msg.challenge);
+        if !valid {
             let c = msg.challenge;
-            warn!("{from}: expected challenge {challenge} but received {c}",);
+            warn!("{from}: challenge {c} is not valid for this source",);
             return Ok(());
         }
-        self.state.challenges.write().unwrap().remove(from);
         self.add_server(*from, ServerInfo::new(msg));
         // FIXME: outdated servers are also counted
         self.stats
@@ -767,25 +765,6 @@ impl<Addr: AddrExt> UdpServerGeneric<Addr> {
         }
 
         Err(UdpServerError::UndefinedPacket)
-    }
-
-    fn server_challenge_add(&mut self, addr: Addr) -> u32 {
-        self.state
-            .challenges
-            .write()
-            .unwrap()
-            .entry(addr)
-            .or_insert_with(|| Timed::new(self.rng.u32(..)))
-            .value
-    }
-
-    fn server_challenge_get(&self, addr: &Addr) -> Option<u32> {
-        self.state
-            .challenges
-            .read()
-            .unwrap()
-            .get(addr)
-            .map(|i| i.value)
     }
 
     fn admin_challenge_add(&mut self, addr: &Addr) -> (u32, u32) {

--- a/crates/xash3d-master/src/udp_server.rs
+++ b/crates/xash3d-master/src/udp_server.rs
@@ -38,8 +38,10 @@ use crate::{
 
 type ServerInfo = xash3d_protocol::ServerInfo<Box<[u8]>>;
 
-pub trait AddrExt: Sized + Eq + Hash + Display + Copy + ToSocketAddrs + ServerAddress {
-    type Ip: Eq + Hash + Display + Copy + FromStr;
+pub trait AddrExt:
+    Sized + Eq + Hash + Display + Copy + ToSocketAddrs + ServerAddress + challenge::Target
+{
+    type Ip: Eq + Hash + Display + Copy + FromStr + challenge::Target;
     type MtuBuffer: AsMut<[u8]>;
 
     fn extract(addr: SocketAddr) -> Result<Self, SocketAddr>;
@@ -416,7 +418,7 @@ impl<Addr: AddrExt> UdpServerGeneric<Addr> {
         msg: &server::Challenge,
     ) -> Result<(), UdpServerError> {
         let window = challenge::current_time_window(self.cfg.server.challenge_window);
-        let challenge = self.state.challenge_key.compute_u32(&from.wrap(), window);
+        let challenge = self.state.challenge_key.compute_u32(from, window);
         let resp = master::ChallengeResponse::new(challenge, msg.server_challenge);
         trace!("{from}: send {resp:?}");
         let mut buf = [0; 32];
@@ -440,7 +442,7 @@ impl<Addr: AddrExt> UdpServerGeneric<Addr> {
         let valid = self
             .state
             .challenge_key
-            .validate_u32(&from.wrap(), window, msg.challenge);
+            .validate_u32(from, window, msg.challenge);
         if !valid {
             let c = msg.challenge;
             warn!("{from}: challenge {c} is not valid for this source",);
@@ -636,9 +638,8 @@ impl<Addr: AddrExt> UdpServerGeneric<Addr> {
 
     fn handle_admin_challenge(&mut self, from: &Addr) -> Result<(), UdpServerError> {
         let window = challenge::current_time_window(self.cfg.server.challenge_window);
-        let ip = from.wrap().ip();
-        let (master_challenge, hash_challenge) =
-            self.state.challenge_key.compute_u32_pair(&ip, window);
+        let (master_challenge, hash_challenge): (u32, u32) =
+            self.state.challenge_key.compute(from.ip(), window);
         let resp = master::AdminChallengeResponse::new(master_challenge, hash_challenge);
         trace!("{from}: send {resp:?}");
         let mut buf = [0; 64];
@@ -653,9 +654,8 @@ impl<Addr: AddrExt> UdpServerGeneric<Addr> {
         msg: &admin::AdminCommand,
     ) -> Result<(), UdpServerError> {
         let window = challenge::current_time_window(self.cfg.server.challenge_window);
-        let ip = from.wrap().ip();
         let hash_challenge = [window, window.wrapping_sub(1)].into_iter().find_map(|w| {
-            let (mc, hc) = self.state.challenge_key.compute_u32_pair(&ip, w);
+            let (mc, hc): (u32, u32) = self.state.challenge_key.compute(from.ip(), w);
             (mc == msg.master_challenge).then_some(hc)
         });
         let Some(hash_challenge) = hash_challenge else {

--- a/crates/xash3d-master/src/udp_server.rs
+++ b/crates/xash3d-master/src/udp_server.rs
@@ -121,8 +121,6 @@ pub enum UdpServerError {
     Protocol(#[from] ProtocolError),
     #[error(transparent)]
     Io(#[from] io::Error),
-    #[error("Admin challenge do not exist")]
-    AdminChallengeNotFound,
     #[error("Undefined packet")]
     UndefinedPacket,
     #[error("Rate limit game request")]
@@ -243,14 +241,14 @@ struct UdpServerState<Addr: AddrExt> {
     blocklist: RwLock<HashSet<Addr::Ip>>,
 
     servers: RwLock<TimedHashMap<Addr, ServerInfo>>,
-    challenge_key: ChallengeKey,
 
-    admin_challenges: RwLock<TimedHashMap<Addr::Ip, (u32, u32)>>,
     // rate limit if hash is invalid
     admin_limit: RwLock<TimedHashMap<Addr::Ip, ()>>,
 
     client_rate_limit: RwLock<TimedHashMap<Addr::Ip, u32>>,
     update_gamedir: RwLock<TimedHashMap<Addr, StrArr<GAMEDIR_MAX_SIZE>>>,
+
+    challenge_key: ChallengeKey,
 }
 
 impl<Addr: AddrExt> UdpServerState<Addr> {
@@ -262,11 +260,10 @@ impl<Addr: AddrExt> UdpServerState<Addr> {
             update_addr: RwLock::new(update_addr),
             blocklist: Default::default(),
             servers: RwLock::new(TimedHashMap::new(timeout.server)),
-            challenge_key,
-            admin_challenges: RwLock::new(TimedHashMap::new(timeout.challenge)),
             admin_limit: RwLock::new(TimedHashMap::new(timeout.admin)),
             update_gamedir: RwLock::new(TimedHashMap::new(5)),
             client_rate_limit: RwLock::new(TimedHashMap::new(1)),
+            challenge_key,
         }
     }
 
@@ -276,16 +273,11 @@ impl<Addr: AddrExt> UdpServerState<Addr> {
         // set timeouts from new config
         let timeout = &cfg.master.server.timeout;
         self.servers.write().unwrap().set_timeout(timeout.server);
-        self.admin_challenges
-            .write()
-            .unwrap()
-            .set_timeout(timeout.challenge);
         self.admin_limit.write().unwrap().set_timeout(timeout.admin);
     }
 
     fn clear(&self) {
         self.servers.write().unwrap().clear();
-        self.admin_challenges.write().unwrap().clear();
         self.admin_limit.write().unwrap().clear();
         self.client_rate_limit.write().unwrap().clear();
         self.update_gamedir.write().unwrap().clear();
@@ -296,7 +288,6 @@ pub struct UdpServerGeneric<Addr: AddrExt> {
     main: bool,
 
     cfg: MasterConfig,
-    rng: Rng,
 
     sock: UdpSocket,
 
@@ -319,7 +310,6 @@ impl<Addr: AddrExt> UdpServerGeneric<Addr> {
             main: true,
 
             sock,
-            rng: Rng::new(),
             state,
             stats: Arc::new(Stats::new(cfg.stat)),
 
@@ -334,7 +324,6 @@ impl<Addr: AddrExt> UdpServerGeneric<Addr> {
         Ok(Self {
             main: false,
             cfg: self.cfg.clone(),
-            rng: Rng::new(),
             sock: bind(self.sock.local_addr()?)?,
             state: Arc::clone(&self.state),
             stats: Arc::clone(&self.stats),
@@ -427,7 +416,7 @@ impl<Addr: AddrExt> UdpServerGeneric<Addr> {
         msg: &server::Challenge,
     ) -> Result<(), UdpServerError> {
         let window = challenge::current_time_window(self.cfg.server.challenge_window);
-        let challenge = self.state.challenge_key.compute(from.wrap(), window);
+        let challenge = self.state.challenge_key.compute_u32(&from.wrap(), window);
         let resp = master::ChallengeResponse::new(challenge, msg.server_challenge);
         trace!("{from}: send {resp:?}");
         let mut buf = [0; 32];
@@ -451,7 +440,7 @@ impl<Addr: AddrExt> UdpServerGeneric<Addr> {
         let valid = self
             .state
             .challenge_key
-            .validate(from.wrap(), window, msg.challenge);
+            .validate_u32(&from.wrap(), window, msg.challenge);
         if !valid {
             let c = msg.challenge;
             warn!("{from}: challenge {c} is not valid for this source",);
@@ -646,7 +635,10 @@ impl<Addr: AddrExt> UdpServerGeneric<Addr> {
     }
 
     fn handle_admin_challenge(&mut self, from: &Addr) -> Result<(), UdpServerError> {
-        let (master_challenge, hash_challenge) = self.admin_challenge_add(from);
+        let window = challenge::current_time_window(self.cfg.server.challenge_window);
+        let ip = from.wrap().ip();
+        let (master_challenge, hash_challenge) =
+            self.state.challenge_key.compute_u32_pair(&ip, window);
         let resp = master::AdminChallengeResponse::new(master_challenge, hash_challenge);
         trace!("{from}: send {resp:?}");
         let mut buf = [0; 64];
@@ -660,18 +652,16 @@ impl<Addr: AddrExt> UdpServerGeneric<Addr> {
         from: &Addr,
         msg: &admin::AdminCommand,
     ) -> Result<(), UdpServerError> {
-        let entry = *self
-            .state
-            .admin_challenges
-            .read()
-            .unwrap()
-            .get(from.ip())
-            .ok_or(UdpServerError::AdminChallengeNotFound)?;
-
-        if entry.0 != msg.master_challenge {
+        let window = challenge::current_time_window(self.cfg.server.challenge_window);
+        let ip = from.wrap().ip();
+        let hash_challenge = [window, window.wrapping_sub(1)].into_iter().find_map(|w| {
+            let (mc, hc) = self.state.challenge_key.compute_u32_pair(&ip, w);
+            (mc == msg.master_challenge).then_some(hc)
+        });
+        let Some(hash_challenge) = hash_challenge else {
             trace!("{from}: master challenge is not valid");
             return Ok(());
-        }
+        };
 
         let state = Params::new()
             .hash_length(self.cfg.hash.len)
@@ -683,7 +673,7 @@ impl<Addr: AddrExt> UdpServerGeneric<Addr> {
             let hash = state
                 .clone()
                 .update(i.password.as_bytes())
-                .update(&entry.1.to_le_bytes())
+                .update(&hash_challenge.to_le_bytes())
                 .finalize();
             *msg.hash == hash.as_bytes()
         });
@@ -692,7 +682,6 @@ impl<Addr: AddrExt> UdpServerGeneric<Addr> {
             Some(admin) => {
                 info!("{from}: admin({}), command: {:?}", &admin.name, msg.command);
                 self.admin_command(msg.command);
-                self.admin_challenge_remove(from);
             }
             None => {
                 warn!("{from}: invalid admin hash, command: {:?}", msg.command);
@@ -765,24 +754,6 @@ impl<Addr: AddrExt> UdpServerGeneric<Addr> {
         }
 
         Err(UdpServerError::UndefinedPacket)
-    }
-
-    fn admin_challenge_add(&mut self, addr: &Addr) -> (u32, u32) {
-        let challenge = (self.rng.u32(..), self.rng.u32(..));
-        self.state
-            .admin_challenges
-            .write()
-            .unwrap()
-            .insert(*addr.ip(), challenge);
-        challenge
-    }
-
-    fn admin_challenge_remove(&mut self, addr: &Addr) {
-        self.state
-            .admin_challenges
-            .write()
-            .unwrap()
-            .remove(addr.ip());
     }
 
     #[allow(dead_code)]


### PR DESCRIPTION
Stateless generator copies the logic of `SV_GetChallenge` from the engine but uses existing BLAKE2b crate.

Time window is calculated since process start and configurable from the config, by default set to 60 seconds, allowing challenges generated in past two minutes