### PR TITLE
query: rename server status "okwithplayers" to "ok"

### DIFF
--- a/crates/xash3d-query/src/server_result.rs
+++ b/crates/xash3d-query/src/server_result.rs
@@ -16,6 +16,8 @@ pub enum ServerResultKind {
         #[serde(flatten)]
         info: ServerInfo,
     },
+    /// An internal enum variant.
+    #[serde(rename = "ok")]
     OkWithPlayers {
         #[serde(flatten)]
         info: ServerInfo,


### PR DESCRIPTION
`ServerResultKind::OkWithPlayers` is an internal enum variant and must not leak to the users.