### PR TITLE
query: lookup server addresses

### DIFF
--- a/crates/xash3d-query/src/cli.rs
+++ b/crates/xash3d-query/src/cli.rs
@@ -12,6 +12,8 @@ use getopts::Options;
 use log::LevelFilter;
 use xash3d_protocol::{self as proto, filter::Version};
 
+use crate::utils::IpVersion;
+
 const BIN_NAME: &str = env!("CARGO_BIN_NAME");
 const PKG_NAME: &str = env!("CARGO_PKG_NAME");
 const PKG_VERSION: &str = env!("CARGO_PKG_VERSION");
@@ -131,6 +133,7 @@ pub struct Cli {
     pub log: LevelFilter,
     force_color: bool,
     pub filter: String,
+    pub ip_version: IpVersion,
 }
 
 impl Default for Cli {
@@ -152,6 +155,7 @@ impl Default for Cli {
             log: LevelFilter::Off,
             force_color: false,
             filter: String::new(),
+            ip_version: IpVersion::Any,
         }
     }
 }
@@ -247,6 +251,8 @@ pub fn parse() -> Cli {
     opts.optopt("g", "filter-gamedir", help, "GAMEDIR");
     let help = "set query filter map [default: all]";
     opts.optopt("m", "filter-map", help, "MAP");
+    let help = "prefered IP version [default: any]";
+    opts.optopt("", "ip-version", help, "VERSION");
 
     let matches = match opts.parse(&args[1..]) {
         Ok(m) => m,
@@ -327,6 +333,18 @@ pub fn parse() -> Cli {
                 process::exit(1);
             }
         };
+    }
+
+    if let Some(s) = matches.opt_str("ip-version") {
+        cli.ip_version = match s.as_str() {
+            "any" => IpVersion::Any,
+            "4" | "v4" => IpVersion::V4,
+            "6" | "v6" => IpVersion::V6,
+            _ => {
+                eprintln!("error: invalid argument {s:?} for --ip-version option");
+                process::exit(1);
+            }
+        }
     }
 
     cli.filter = filter.opt_get(&matches);

--- a/crates/xash3d-query/src/main.rs
+++ b/crates/xash3d-query/src/main.rs
@@ -32,7 +32,7 @@ fn execute(cli: Cli) -> Result<(), QueryError> {
         }
         "info" => {
             // Query info for user specified servers.
-            let list = parse_server_addresses(&cli.args[1..]);
+            let list = parse_server_addresses(&cli.args[1..], cli.ip_version);
             query_servers_info::run_custom_servers(&cli, list)?;
         }
         "list" => {
@@ -41,7 +41,7 @@ fn execute(cli: Cli) -> Result<(), QueryError> {
         }
         "monitor" => {
             // Monitor servers in real time.
-            let list = parse_server_addresses(&cli.args[1..]);
+            let list = parse_server_addresses(&cli.args[1..], cli.ip_version);
             monitor_servers::run(&cli, list)?;
         }
         _ => return Err(QueryError::UndefinedCommand),

--- a/crates/xash3d-query/src/monitor_servers.rs
+++ b/crates/xash3d-query/src/monitor_servers.rs
@@ -1,6 +1,7 @@
 use std::{
     collections::{hash_map::Entry, HashMap},
     net::SocketAddr,
+    time::Duration,
 };
 
 use xash3d_observer::{event::Event, Buffer, Server};
@@ -8,24 +9,67 @@ use xash3d_observer::{event::Event, Buffer, Server};
 use crate::{
     cli::Cli,
     server_info::ServerInfo,
-    server_result::{ServerResult, ServerResultKind},
+    server_result::{ServerAddress, ServerResult, ServerResultKind},
     utils::{self, print_json},
     QueryError,
 };
 
-pub(crate) fn run(cli: &Cli, servers: Vec<SocketAddr>) -> Result<(), QueryError> {
+struct Monitor<'a> {
+    cli: &'a Cli,
+    servers: HashMap<SocketAddr, ServerInfo>,
+    domains: HashMap<SocketAddr, String>,
+}
+
+impl<'a> Monitor<'a> {
+    fn new(cli: &'a Cli) -> Self {
+        Self {
+            cli,
+            servers: HashMap::new(),
+            domains: HashMap::new(),
+        }
+    }
+
+    fn print_json(&self, mut result: ServerResult) {
+        if let Some(domain) = self.domains.get(&result.address.resolved) {
+            result.address.domain = Some(domain.clone());
+        }
+        print_json(self.cli, &result);
+    }
+
+    fn print_info(&mut self, addr: SocketAddr, ping: Duration, info: ServerInfo) {
+        match self.servers.entry(addr) {
+            Entry::Occupied(mut e) => {
+                let p = e.get().printer(self.cli);
+                println!("{:24?} --- {:>7.1} {}", addr, ' ', p,);
+                let p = info.printer(self.cli);
+                println!("{addr:24?} +++ {ping:>7.1?} {p}");
+                e.insert(info);
+            }
+            Entry::Vacant(e) => {
+                let p = info.printer(self.cli);
+                println!("{addr:24?} +++ {ping:>7.1?} {p}");
+                e.insert(info);
+            }
+        }
+    }
+}
+
+pub(crate) fn run(cli: &Cli, servers: Vec<ServerAddress>) -> Result<(), QueryError> {
     let mut observer = if servers.is_empty() {
         utils::create_observer_with_masters(cli)?
     } else {
         utils::create_observer(cli)?
     };
 
+    let mut monitor = Monitor::new(cli);
     for addr in servers {
-        let server = Server::new(addr);
+        if let Some(domain) = addr.domain {
+            monitor.domains.insert(addr.resolved, domain);
+        }
+        let server = Server::new(addr.resolved);
         observer.insert_server(server);
     }
 
-    let mut servers = HashMap::<SocketAddr, ServerInfo>::new();
     let mut buffer = Buffer::new();
     loop {
         match observer.wait_event(&mut buffer, None)? {
@@ -42,39 +86,25 @@ pub(crate) fn run(cli: &Cli, servers: Vec<SocketAddr>) -> Result<(), QueryError>
                 if cli.json {
                     let mut result = ServerResult::new_timeout(addr);
                     result.set_ok(ping, info);
-                    print_json(cli, &result);
+                    monitor.print_json(result);
                 } else {
-                    match servers.entry(addr) {
-                        Entry::Occupied(mut e) => {
-                            let p = e.get().printer(cli);
-                            println!("{:24?} --- {:>7.1} {}", addr, ' ', p,);
-                            let p = info.printer(cli);
-                            println!("{addr:24?} +++ {ping:>7.1?} {p}");
-                            e.insert(info);
-                        }
-                        Entry::Vacant(e) => {
-                            let p = info.printer(cli);
-                            println!("{addr:24?} +++ {ping:>7.1?} {p}");
-                            e.insert(info);
-                        }
-                    }
+                    monitor.print_info(addr, ping, info);
                 }
             }
             Event::ServerInfo(server_info) if cli.json && !server_info.is_changed() => {
                 let result = ServerResult::new_ping(*server_info.address(), server_info.ping());
-                print_json(cli, &result);
+                monitor.print_json(result);
             }
             Event::ServerInfoTimeout(addr) if cli.json => {
                 let result = ServerResult::new_timeout(addr);
-                print_json(cli, &result);
+                monitor.print_json(result);
+            }
+            Event::ServerRemove(addr) if cli.json => {
+                let result = ServerResult::new(addr, None, ServerResultKind::Remove);
+                monitor.print_json(result);
             }
             Event::ServerRemove(addr) => {
-                if cli.json {
-                    let result = ServerResult::new(addr, None, ServerResultKind::Remove);
-                    print_json(cli, &result);
-                } else {
-                    servers.remove(&addr);
-                }
+                monitor.servers.remove(&addr);
             }
             _ => {}
         }

--- a/crates/xash3d-query/src/query_servers_info.rs
+++ b/crates/xash3d-query/src/query_servers_info.rs
@@ -13,7 +13,7 @@ use crate::{
     cli::Cli,
     color::Colored,
     server_info::{PlayerInfo, Players, ServerInfo},
-    server_result::{ServerResult, ServerResultKind},
+    server_result::{ServerAddress, ServerResult, ServerResultKind},
     utils::{self, print_json},
     QueryError,
 };
@@ -78,21 +78,27 @@ impl<'a> Printer<'a> {
         }
     }
 
-    fn label_server(&self, address: SocketAddr) -> impl fmt::Display {
-        struct LabelServer {
+    fn label_server<'b>(&self, result: &'b ServerResult) -> impl fmt::Display + 'b {
+        struct LabelServer<'a> {
             label: Label,
-            address: SocketAddr,
+            result: &'a ServerResult,
         }
 
-        impl fmt::Display for LabelServer {
+        impl fmt::Display for LabelServer<'_> {
             fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-                write!(f, "{}: {}", self.label, self.address)
+                write!(f, "{}: ", self.label)?;
+                if let Some(addr) = &self.result.address.domain {
+                    write!(f, "{addr}")?;
+                } else {
+                    write!(f, "{}", self.result.address.resolved)?;
+                }
+                Ok(())
             }
         }
 
         LabelServer {
             label: self.label("server"),
-            address,
+            result,
         }
     }
 
@@ -116,7 +122,7 @@ impl<'a> Printer<'a> {
     }
 
     fn print_server_info(&mut self, cli: &Cli, server: &ServerResult, info: &ServerInfo) {
-        print!("{}", self.label_server(server.address));
+        print!("{}", self.label_server(server));
         if let Some(ping) = server.ping_millis_f32() {
             print!(" [ping {ping:.0}ms]");
         }
@@ -172,15 +178,15 @@ impl<'a> Printer<'a> {
     }
 
     fn print_timeout(&mut self, _: &Cli, server: &ServerResult) {
-        println!("{} [timeout]", self.label_server(server.address));
+        println!("{} [timeout]", self.label_server(server));
     }
 
     fn print_invalid_protocol(&mut self, _: &Cli, server: &ServerResult) {
-        println!("{} [protocol error]", self.label_server(server.address));
+        println!("{} [protocol error]", self.label_server(server));
     }
 
     fn print_invalid_packet(&mut self, _: &Cli, server: &ServerResult) {
-        println!("{} [invalid]", self.label_server(server.address));
+        println!("{} [invalid]", self.label_server(server));
     }
 
     fn print(&mut self, cli: &Cli) {
@@ -257,33 +263,41 @@ impl QueryServersInfo {
         }
     }
 
-    fn insert_custom_server(&mut self, addr: SocketAddr) {
-        self.servers_custom.insert(addr);
-        self.insert_server(addr);
+    fn insert_custom_server(&mut self, server: ServerAddress) {
+        self.servers_custom.insert(server.resolved);
+        self.insert_server(server.resolved, server.domain);
     }
 
-    fn insert_server(&mut self, addr: SocketAddr) {
-        let server = Server::new(addr).with_players(self.players);
+    fn insert_server(&mut self, resolved: SocketAddr, address: Option<String>) {
+        let server = Server::new(resolved).with_players(self.players);
         self.observer.insert_server(server);
 
         // Set default result to timeout for all new servers.
-        if let Entry::Vacant(e) = self.servers.entry(addr) {
-            e.insert(ServerResult::new_timeout(addr));
+        if let Entry::Vacant(e) = self.servers.entry(resolved) {
+            let mut result = ServerResult::new_timeout(resolved);
+            if let Some(address) = address {
+                result.address.domain = Some(address);
+            }
+            e.insert(result);
         }
     }
 
-    fn set_server_result(&mut self, addr: SocketAddr, result: ServerResult) {
+    fn set_server_result_kind(&mut self, addr: SocketAddr, kind: ServerResultKind) {
+        let Some(e) = self.servers.get_mut(&addr) else {
+            eprintln!("warning: unexpected server {addr}");
+            return;
+        };
         if self.custom {
             self.servers_custom.remove(&addr);
         }
-        self.servers.insert(addr, result);
+        e.kind = kind;
     }
 
     fn set_server_result_ok(&mut self, addr: SocketAddr, ping: Duration, info: ServerInfo) {
-        let e = self
-            .servers
-            .entry(addr)
-            .or_insert_with(|| ServerResult::new_timeout(addr));
+        let Some(e) = self.servers.get_mut(&addr) else {
+            eprintln!("warning: unexpected server {addr}");
+            return;
+        };
         if self.custom && (!self.players || e.has_players()) {
             self.servers_custom.remove(&addr);
         }
@@ -317,7 +331,7 @@ impl QueryServersInfo {
                     }
 
                     for addr in list.iter() {
-                        self.insert_server(addr);
+                        self.insert_server(addr, None);
                     }
                 }
                 Event::ServerInfo(server_info) => {
@@ -329,14 +343,14 @@ impl QueryServersInfo {
                     self.set_server_players(addr, players.into());
                 }
                 Event::ServerInvalidProtocol(addr) => {
-                    let result = ServerResult::new_invalid_protocol(addr);
-                    self.set_server_result(addr, result);
+                    let kind = ServerResultKind::InvalidProtocol;
+                    self.set_server_result_kind(addr, kind);
                 }
                 Event::ServerInvalidPacket(addr, data) => {
                     let result = self.servers.get(&addr);
                     if result.is_none() || result.is_some_and(|i| i.kind.is_timeout()) {
-                        let result = ServerResult::new_invalid_packet(addr, data);
-                        self.set_server_result(addr, result);
+                        let kind = ServerResultKind::InvalidPacket { data: data.into() };
+                        self.set_server_result_kind(addr, kind);
                     }
                 }
                 _ => {}
@@ -346,7 +360,7 @@ impl QueryServersInfo {
         }
 
         let mut servers: Vec<_> = self.servers.into_values().collect();
-        servers.sort_by_key(|a| a.address);
+        servers.sort_by_key(|a| a.address.resolved);
         Printer::new(cli, self.custom, &servers).print(cli);
 
         Ok(())
@@ -359,15 +373,15 @@ pub(crate) fn run(cli: &Cli) -> Result<(), QueryError> {
     query.run(cli)
 }
 
-pub(crate) fn run_custom_servers(cli: &Cli, servers: Vec<SocketAddr>) -> Result<(), QueryError> {
+pub(crate) fn run_custom_servers(cli: &Cli, servers: Vec<ServerAddress>) -> Result<(), QueryError> {
     if servers.is_empty() {
         return Ok(());
     }
 
     let observer = utils::create_observer(cli)?;
     let mut query = QueryServersInfo::new(cli, observer, true);
-    for addr in servers {
-        query.insert_custom_server(addr);
+    for i in servers {
+        query.insert_custom_server(i);
     }
     query.run(cli)
 }

--- a/crates/xash3d-query/src/server_result.rs
+++ b/crates/xash3d-query/src/server_result.rs
@@ -4,7 +4,7 @@ use std::{
     time::{Duration, SystemTime},
 };
 
-use serde::{Serialize, Serializer};
+use serde::{ser::SerializeStruct, Serialize, Serializer};
 
 use crate::server_info::{Players, ServerInfo};
 
@@ -48,11 +48,36 @@ fn make_millis_f32(ping: Duration) -> f32 {
     ping.as_micros() as f32 / 1000.0
 }
 
+#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord)]
+pub struct ServerAddress {
+    pub domain: Option<String>,
+    pub resolved: SocketAddr,
+}
+
+impl Serialize for ServerAddress {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        if let Some(domain) = &self.domain {
+            let mut s = serializer.serialize_struct("ServerAddress", 2)?;
+            s.serialize_field("address", &domain)?;
+            s.serialize_field("resolved", &self.resolved)?;
+            s.end()
+        } else {
+            let mut s = serializer.serialize_struct("ServerAddress", 1)?;
+            s.serialize_field("address", &self.resolved)?;
+            s.end()
+        }
+    }
+}
+
 #[derive(Clone, Debug, Serialize)]
 pub struct ServerResult {
     #[serde(serialize_with = "serialize_unix_time")]
     pub time: SystemTime,
-    pub address: SocketAddr,
+    #[serde(flatten)]
+    pub address: ServerAddress,
     #[serde(skip_serializing_if = "Option::is_none")]
     #[serde(serialize_with = "serialize_ping")]
     pub ping: Option<Duration>,
@@ -64,10 +89,13 @@ pub struct ServerResult {
 }
 
 impl ServerResult {
-    pub fn new(address: SocketAddr, ping: Option<Duration>, kind: ServerResultKind) -> Self {
+    pub fn new(resolved: SocketAddr, ping: Option<Duration>, kind: ServerResultKind) -> Self {
         Self {
             time: SystemTime::now(),
-            address,
+            address: ServerAddress {
+                domain: None,
+                resolved,
+            },
             ping,
             kind,
             players: None,
@@ -80,20 +108,6 @@ impl ServerResult {
 
     pub fn new_timeout(address: SocketAddr) -> Self {
         Self::new(address, None, ServerResultKind::Timeout)
-    }
-
-    pub fn new_invalid_protocol(address: SocketAddr) -> Self {
-        Self::new(address, None, ServerResultKind::InvalidProtocol)
-    }
-
-    pub fn new_invalid_packet(address: SocketAddr, response: &[u8]) -> Self {
-        Self::new(
-            address,
-            None,
-            ServerResultKind::InvalidPacket {
-                data: response.into(),
-            },
-        )
     }
 
     pub fn ping_millis_f32(&self) -> Option<f32> {

--- a/crates/xash3d-query/src/utils.rs
+++ b/crates/xash3d-query/src/utils.rs
@@ -7,7 +7,7 @@ use std::{
 use serde::Serialize;
 use xash3d_observer::{Master, Observer};
 
-use crate::cli::Cli;
+use crate::{cli::Cli, server_result::ServerAddress};
 
 pub fn create_observer(cli: &Cli) -> io::Result<Observer> {
     let mut observer = Observer::new()?;
@@ -35,19 +35,70 @@ pub fn create_observer_with_masters(cli: &Cli) -> io::Result<Observer> {
     Ok(observer)
 }
 
-pub fn parse_server_addresses(servers: &[String]) -> Vec<SocketAddr> {
+#[derive(Copy, Clone, Debug, PartialEq, Eq)]
+pub enum IpVersion {
+    Any,
+    V4,
+    V6,
+}
+
+impl IpVersion {
+    pub fn matches(&self, addr: &SocketAddr) -> bool {
+        match self {
+            IpVersion::Any => true,
+            IpVersion::V4 => addr.is_ipv4(),
+            IpVersion::V6 => addr.is_ipv6(),
+        }
+    }
+}
+
+pub fn parse_server_addresses(servers: &[String], ip_version: IpVersion) -> Vec<ServerAddress> {
     let mut list = Vec::with_capacity(servers.len());
-    for i in servers {
-        match i.parse() {
-            Ok(addr) => list.push(addr),
-            Err(_) => eprintln!("invalid address {i}"),
+    for address in servers {
+        if let Ok(addr) = address.parse() {
+            list.push(ServerAddress {
+                domain: None,
+                resolved: addr,
+            });
+            continue;
+        }
+
+        match address.to_socket_addrs() {
+            Ok(addrs) => {
+                let mut addr = None;
+                for i in addrs {
+                    // match exact version
+                    if ip_version.matches(&i) {
+                        addr = Some(i);
+                        break;
+                    }
+
+                    // fallback to any version
+                    if addr.is_none() {
+                        addr = Some(i);
+                    }
+                }
+
+                if let Some(addr) = addr {
+                    // found address for a server
+                    list.push(ServerAddress {
+                        domain: Some(address.clone()),
+                        resolved: addr,
+                    });
+                } else {
+                    eprintln!("warning: no IP address for server {address}");
+                }
+            }
+            Err(e) => {
+                eprintln!("error: invalid server address {address}, {e}");
+            }
         }
     }
     if servers.len() != list.len() {
         process::exit(1);
     }
     list.sort_unstable();
-    list.dedup();
+    list.dedup_by_key(|i| i.resolved);
     list
 }
 


### PR DESCRIPTION
Related https://github.com/FWGS/server-list/pull/13.

if a server address contains a domain name it will be resolved to a socket address. The socket address will be in a new key `resolved`. Preferred IP version for address resolutions can be specified by `--ip-version` option.

```
xash3d-query info -jP ganymede.workbench.network:27018
```

```json
{
  "servers": [
    {
      "time": 1782292054,
      "address": "ganymede.workbench.network:27018",
      "resolved": "135.181.160.44:27018",
      "ping": 100.77,
      "status": "ok",
      "gamedir": "tfc",
      "map": "rock2",
      "host": "TFC 1.5 | Europe",
      "protocol": 49,
      "numcl": 0,
      "maxcl": 32,
      "dm": false,
      "team": false,
      "coop": false,
      "password": false,
      "dedicated": true
    }
  ]
}
```